### PR TITLE
RISC-V: Prohibit relaxing the initial gp generation

### DIFF
--- a/sysdeps/riscv/start.S
+++ b/sysdeps/riscv/start.S
@@ -65,7 +65,10 @@ END(ENTRY_POINT)
    So we redundantly initialize it at the beginning of _start.  */
 
 .Lload_gp:
+.option push
+.option norelax
 	lla   gp, __global_pointer$
+.option pop
 	ret
 
 	.section .preinit_array,"aw"


### PR DESCRIPTION
I've added an additional linker relaxation that relaxes two instruction
pc-relative sequences to one instruction gp relative sequences when
possible.  This sequence now optimizes the initial gp generation to

  mv gp, gp

which is obviously bogus.  The fix is to disable relaxations when
setting up gp, preventing the linker from relaxing away this setup code.