### PR TITLE
Fix header comments based on feedback.

### DIFF
--- a/sysdeps/riscv/__longjmp.S
+++ b/sysdeps/riscv/__longjmp.S
@@ -1,5 +1,5 @@
-/* Copyright (C) 1996, 1997, 2000, 2002-2004, 2017
-	Free Software Foundation, Inc.
+/* longjmp, RISC-V version.
+   Copyright (C) 1996-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sysdep.h>
 #include <sys/asm.h>

--- a/sysdeps/riscv/atomic-machine.h
+++ b/sysdeps/riscv/atomic-machine.h
@@ -1,8 +1,5 @@
 /* Low-level functions for atomic operations. RISC-V version.
    Copyright (C) 2011-2016 Free Software Foundation, Inc.
-
-   Contributed by Andrew Waterman (andrew@sifive.com).
-
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -16,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _RISCV_BITS_ATOMIC_H
 #define _RISCV_BITS_ATOMIC_H 1

--- a/sysdeps/riscv/bits/fenv.h
+++ b/sysdeps/riscv/bits/fenv.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 1998, 1999, 2000, 2017 Free Software Foundation, Inc.
+/* Floating point environment, RISC-V version.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _FENV_H
 # error "Never use <bits/fenv.h> directly; include <fenv.h> instead."

--- a/sysdeps/riscv/bits/link.h
+++ b/sysdeps/riscv/bits/link.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2005, 2009, 2017 Free Software Foundation, Inc.
+/* Machine-specific declarations for dynamic linker interface.  RISC-V version.
+   Copyright (C) 2005-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef	_LINK_H
 # error "Never include <bits/link.h> directly; use <link.h> instead."

--- a/sysdeps/riscv/bits/setjmp.h
+++ b/sysdeps/riscv/bits/setjmp.h
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _RISCV_BITS_SETJMP_H
 #define _RISCV_BITS_SETJMP_H

--- a/sysdeps/riscv/bits/wordsize.h
+++ b/sysdeps/riscv/bits/wordsize.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2002, 2003, 2017 Free Software Foundation, Inc.
+/* Determine the wordsize from the preprocessor defines.  RISC-V version.
+   Copyright (C) 2002-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #if __riscv_xlen == (__SIZEOF_POINTER__ * 8)
 # define __WORDSIZE __riscv_xlen

--- a/sysdeps/riscv/dl-machine.h
+++ b/sysdeps/riscv/dl-machine.h
@@ -1,6 +1,5 @@
 /* Machine-dependent ELF dynamic relocation inline functions.  RISC-V version.
    Copyright (C) 2011-2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/dl-tls.h
+++ b/sysdeps/riscv/dl-tls.h
@@ -1,6 +1,5 @@
 /* Thread-local storage handling in the ELF dynamic linker.  RISC-V version.
    Copyright (C) 2011-2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/fpu_control.h
+++ b/sysdeps/riscv/fpu_control.h
@@ -1,8 +1,6 @@
 /* FPU control word bits.  RISC-V version.
-   Copyright (C) 1996, 1997, 1998, 1999, 2000, 2006, 2008, 2017
-   Free Software Foundation, Inc.
+   Copyright (C) 1996-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Olaf Flebbe and Ralf Baechle.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -15,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _FPU_CONTROL_H
 #define _FPU_CONTROL_H

--- a/sysdeps/riscv/gccframe.h
+++ b/sysdeps/riscv/gccframe.h
@@ -1,5 +1,5 @@
 /* Definition of object in frame unwind info.  RISC-V version.
-   Copyright (C) 2001, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2001-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #define FIRST_PSEUDO_REGISTER 66
 

--- a/sysdeps/riscv/jmpbuf-unwind.h
+++ b/sysdeps/riscv/jmpbuf-unwind.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2003, 2005, 2006, 2017 Free Software Foundation, Inc.
+/* Examine __jmp_buf for unwinding frames.  RISC-V version.
+   Copyright (C) 2003-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <setjmp.h>
 #include <stdint.h>

--- a/sysdeps/riscv/ldsodefs.h
+++ b/sysdeps/riscv/ldsodefs.h
@@ -1,6 +1,5 @@
 /* Run-time dynamic linker data structures for loaded ELF shared objects.
    Copyright (C) 2011-2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/libc-tls.c
+++ b/sysdeps/riscv/libc-tls.c
@@ -1,6 +1,5 @@
 /* Thread-local storage handling in the ELF dynamic linker.  RISC-V version.
    Copyright (C) 2011-2016 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/memcpy.c
+++ b/sysdeps/riscv/memcpy.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2011-2017 Free Software Foundation, Inc.
+/* Optimized memory copy implementation for RISC-V.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/memset.S
+++ b/sysdeps/riscv/memset.S
@@ -1,5 +1,5 @@
-/* Copyright (C) 2011-2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Optimized memset implementation for RISC-V.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/memusage.h
+++ b/sysdeps/riscv/memusage.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2000, 2017 Free Software Foundation, Inc.
+/* Machine-specific definitions for memory usage profiling, RISC-V version.
+   Copyright (C) 2000-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #define GETSP() ({ register uintptr_t stack_ptr asm ("sp"); stack_ptr; })
 

--- a/sysdeps/riscv/nptl/Makefile
+++ b/sysdeps/riscv/nptl/Makefile
@@ -1,4 +1,5 @@
-# Copyright (C) 2005 Free Software Foundation, Inc.
+# Makefile for sysdeps/riscv/nptl.
+# Copyright (C) 2005-2017 Free Software Foundation, Inc.
 # This file is part of the GNU C Library.
 #
 # The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
 # Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with the GNU C Library; if not, write to the Free
-# Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307 USA.
+# License along with the GNU C Library; if not, see
+# <http://www.gnu.org/licenses/>.
 
 ifeq ($(subdir),csu)
 gen-as-const-headers += tcb-offsets.sym

--- a/sysdeps/riscv/nptl/bits/pthreadtypes-arch.h
+++ b/sysdeps/riscv/nptl/bits/pthreadtypes-arch.h
@@ -1,5 +1,5 @@
 /* Machine-specific pthread type layouts.  RISC-V version.
-   Copyright (C) 2011-2014, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _BITS_PTHREADTYPES_ARCH_H
 #define _BITS_PTHREADTYPES_ARCH_H	1

--- a/sysdeps/riscv/nptl/bits/semaphore.h
+++ b/sysdeps/riscv/nptl/bits/semaphore.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2002, 2005, 2007, 2017 Free Software Foundation, Inc.
+/* Machine-specific POSIX semaphore type layouts.  RISC-V version.
+   Copyright (C) 2002-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _SEMAPHORE_H
 # error "Never use <bits/semaphore.h> directly; include <semaphore.h> instead."

--- a/sysdeps/riscv/nptl/pthreaddef.h
+++ b/sysdeps/riscv/nptl/pthreaddef.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2011-2014, 2017 Free Software Foundation, Inc.
+/* pthread machine parameter definitions,  RISC-V version.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 /* Default stack size.  */
 #define ARCH_STACK_DEFAULT_SIZE	(2 * 1024 * 1024)

--- a/sysdeps/riscv/nptl/tls.h
+++ b/sysdeps/riscv/nptl/tls.h
@@ -1,5 +1,5 @@
 /* Definition for thread-local data handling.  NPTL/RISC-V version.
-   Copyright (C) 2011-2014, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _RISCV_TLS_H
 #define _RISCV_TLS_H	1

--- a/sysdeps/riscv/rv64/rvd/s_ceil.c
+++ b/sysdeps/riscv/rv64/rvd/s_ceil.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* ceil().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rv64/rvd/s_floor.c
+++ b/sysdeps/riscv/rv64/rvd/s_floor.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* floor().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rv64/rvd/s_llrint.c
+++ b/sysdeps/riscv/rv64/rvd/s_llrint.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* llrint().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rv64/rvd/s_llround.c
+++ b/sysdeps/riscv/rv64/rvd/s_llround.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* llround().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rv64/rvd/s_nearbyint.c
+++ b/sysdeps/riscv/rv64/rvd/s_nearbyint.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* nearbyint().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rv64/rvd/s_rint.c
+++ b/sysdeps/riscv/rv64/rvd/s_rint.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* rint().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rv64/rvd/s_round.c
+++ b/sysdeps/riscv/rv64/rvd/s_round.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* round().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rv64/rvd/s_trunc.c
+++ b/sysdeps/riscv/rv64/rvd/s_trunc.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* trunc().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rv64/rvf/s_llrintf.c
+++ b/sysdeps/riscv/rv64/rvf/s_llrintf.c
@@ -1,5 +1,6 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Round argument to nearest integral value according to current rounding
+   direction.  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rv64/rvf/s_llroundf.c
+++ b/sysdeps/riscv/rv64/rvf/s_llroundf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Round float value to long long int.  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/e_sqrt.c
+++ b/sysdeps/riscv/rvd/e_sqrt.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Double precision floating point square root.  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_copysign.c
+++ b/sysdeps/riscv/rvd/s_copysign.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Copy sign bit between floating-point values.  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_finite.c
+++ b/sysdeps/riscv/rvd/s_finite.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* finite().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_fma.c
+++ b/sysdeps/riscv/rvd/s_fma.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Double precision floating point fused multiply-add.  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_fmax.c
+++ b/sysdeps/riscv/rvd/s_fmax.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* fmax().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_fmin.c
+++ b/sysdeps/riscv/rvd/s_fmin.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* fmin().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_fpclassify.c
+++ b/sysdeps/riscv/rvd/s_fpclassify.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* fpclassify().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_isinf.c
+++ b/sysdeps/riscv/rvd/s_isinf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* isinf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_isnan.c
+++ b/sysdeps/riscv/rvd/s_isnan.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* isnan().  RISC_V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_issignaling.c
+++ b/sysdeps/riscv/rvd/s_issignaling.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* issignaling().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_lrint.c
+++ b/sysdeps/riscv/rvd/s_lrint.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* lrint().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvd/s_lround.c
+++ b/sysdeps/riscv/rvd/s_lround.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* lround().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/e_sqrtf.c
+++ b/sysdeps/riscv/rvf/e_sqrtf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Single precision floating point square root.  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/fclrexcpt.c
+++ b/sysdeps/riscv/rvf/fclrexcpt.c
@@ -1,7 +1,6 @@
 /* Clear given exceptions in current floating-point environment.
-   Copyright (C) 1998-2000, 2002, 2017 Free Software Foundation, Inc.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@suse.de>, 1998.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <fpu_control.h>

--- a/sysdeps/riscv/rvf/fegetenv.c
+++ b/sysdeps/riscv/rvf/fegetenv.c
@@ -1,7 +1,6 @@
 /* Store current floating-point environment.
-   Copyright (C) 1998-2000, 2002, 2010, 2017 Free Software Foundation, Inc.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@suse.de>, 1998.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <fpu_control.h>

--- a/sysdeps/riscv/rvf/fegetround.c
+++ b/sysdeps/riscv/rvf/fegetround.c
@@ -1,7 +1,6 @@
 /* Return current rounding direction.
-   Copyright (C) 1998, 2017 Free Software Foundation, Inc.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@arthur.rhein-neckar.de>, 1998.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <math_private.h>

--- a/sysdeps/riscv/rvf/feholdexcpt.c
+++ b/sysdeps/riscv/rvf/feholdexcpt.c
@@ -1,7 +1,6 @@
 /* Store current floating-point environment and clear exceptions.
-   Copyright (C) 2000, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2000-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@suse.de>, 2000.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <math_private.h>

--- a/sysdeps/riscv/rvf/fesetenv.c
+++ b/sysdeps/riscv/rvf/fesetenv.c
@@ -1,7 +1,6 @@
 /* Install given floating-point environment.
-   Copyright (C) 1998-2000, 2002, 2017 Free Software Foundation, Inc.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@suse.de>, 1998.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <math_private.h>

--- a/sysdeps/riscv/rvf/fesetround.c
+++ b/sysdeps/riscv/rvf/fesetround.c
@@ -1,7 +1,6 @@
 /* Set current rounding direction.
-   Copyright (C) 1998, 2017 Free Software Foundation, Inc.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@arthur.rhein-neckar.de>, 1998.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <math_private.h>

--- a/sysdeps/riscv/rvf/feupdateenv.c
+++ b/sysdeps/riscv/rvf/feupdateenv.c
@@ -1,7 +1,6 @@
 /* Install given floating-point environment and raise exceptions.
-   Copyright (C) 1998-2000, 2002, 2010, 2017 Free Software Foundation, Inc.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@suse.de>, 1998.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <math_private.h>

--- a/sysdeps/riscv/rvf/fgetexcptflg.c
+++ b/sysdeps/riscv/rvf/fgetexcptflg.c
@@ -1,7 +1,6 @@
 /* Store current representation for exceptions.
-   Copyright (C) 1998-2000, 2002, 2017 Free Software Foundation, Inc.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@suse.de>, 1998.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <math_private.h>

--- a/sysdeps/riscv/rvf/fraiseexcpt.c
+++ b/sysdeps/riscv/rvf/fraiseexcpt.c
@@ -1,7 +1,6 @@
 /* Raise given exceptions.
-   Copyright (C) 2000, 2002, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2000-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@suse.de>, 2000.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <fpu_control.h>

--- a/sysdeps/riscv/rvf/fsetexcptflg.c
+++ b/sysdeps/riscv/rvf/fsetexcptflg.c
@@ -1,7 +1,6 @@
 /* Set floating-point environment exception handling.
-   Copyright (C) 1998-2000, 2002, 2017 Free Software Foundation, Inc.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Hartvig Ekner <hartvige@mips.com>, 2002.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <fpu_control.h>

--- a/sysdeps/riscv/rvf/ftestexcept.c
+++ b/sysdeps/riscv/rvf/ftestexcept.c
@@ -1,7 +1,6 @@
 /* Test exception in current environment.
-   Copyright (C) 1998, 2010, 2017 Free Software Foundation, Inc.
+   Copyright (C) 1998-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@arthur.rhein-neckar.de>, 1998.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <fenv.h>
 #include <math_private.h>

--- a/sysdeps/riscv/rvf/get-rounding-mode.h
+++ b/sysdeps/riscv/rvf/get-rounding-mode.h
@@ -1,7 +1,5 @@
 /* Determine floating-point rounding mode within libc.  RISC-V version.
-
-   Copyright (C) 2015, 2017 Free Software Foundation, Inc.
-
+   Copyright (C) 2015-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/math_private.h
+++ b/sysdeps/riscv/rvf/math_private.h
@@ -1,5 +1,5 @@
 /* Private floating point rounding and exceptions handling.  RISC-V version.
-   Copyright (C) 2014-2015, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2014-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_ceilf.c
+++ b/sysdeps/riscv/rvf/s_ceilf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* ceilf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_copysignf.c
+++ b/sysdeps/riscv/rvf/s_copysignf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* copysignf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_finitef.c
+++ b/sysdeps/riscv/rvf/s_finitef.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* finitef().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_floorf.c
+++ b/sysdeps/riscv/rvf/s_floorf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* floorf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_fmaf.c
+++ b/sysdeps/riscv/rvf/s_fmaf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* fmaf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_fmaxf.c
+++ b/sysdeps/riscv/rvf/s_fmaxf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* fmaxf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_fminf.c
+++ b/sysdeps/riscv/rvf/s_fminf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* fminf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_fpclassifyf.c
+++ b/sysdeps/riscv/rvf/s_fpclassifyf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* fpclassifyf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_isinff.c
+++ b/sysdeps/riscv/rvf/s_isinff.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* isinff().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_isnanf.c
+++ b/sysdeps/riscv/rvf/s_isnanf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* isnanf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_issignalingf.c
+++ b/sysdeps/riscv/rvf/s_issignalingf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* issignalingf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_lrintf.c
+++ b/sysdeps/riscv/rvf/s_lrintf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* lrintf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_lroundf.c
+++ b/sysdeps/riscv/rvf/s_lroundf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* lroundf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_nearbyintf.c
+++ b/sysdeps/riscv/rvf/s_nearbyintf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Round to int floating-point values.  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_rintf.c
+++ b/sysdeps/riscv/rvf/s_rintf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* rintf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_roundf.c
+++ b/sysdeps/riscv/rvf/s_roundf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* roundf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/rvf/s_truncf.c
+++ b/sysdeps/riscv/rvf/s_truncf.c
@@ -1,5 +1,5 @@
-/* Copyright (C) 2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* truncf().  RISC-V version.
+   Copyright (C) 2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/setjmp.S
+++ b/sysdeps/riscv/setjmp.S
@@ -1,5 +1,5 @@
-/* Copyright (C) 1996, 1997, 2000, 2002, 2003, 2004
-	Free Software Foundation, Inc.
+/* setjmp for RISC-V.
+   Copyright (C) 1996-2004 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sysdep.h>
 #include <sys/asm.h>

--- a/sysdeps/riscv/stackinfo.h
+++ b/sysdeps/riscv/stackinfo.h
@@ -1,5 +1,5 @@
-/* Copyright (C) 2011-2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Stack environment definitions for RISC-V.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/start.S
+++ b/sysdeps/riscv/start.S
@@ -1,6 +1,5 @@
 /* Startup code compliant to the ELF RISC-V ABI.
-   Copyright (C) 1995, 1997, 2000-2004, 2017
-	Free Software Foundation, Inc.
+   Copyright (C) 1995-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -31,9 +30,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #define __ASSEMBLY__ 1
 #include <entry.h>

--- a/sysdeps/riscv/strcmp.S
+++ b/sysdeps/riscv/strcmp.S
@@ -1,5 +1,5 @@
-/* Copyright (C) 2011-2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* Optimized string compare implementation for RISC-V.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/strcpy.c
+++ b/sysdeps/riscv/strcpy.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2011-2017 Free Software Foundation, Inc.
+/* Optimized string copy implementation for RISC-V.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/strlen.c
+++ b/sysdeps/riscv/strlen.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2011-2017 Free Software Foundation, Inc.
+/* Determine the length of a string.  RISC-V version.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/riscv/sys/asm.h
+++ b/sysdeps/riscv/sys/asm.h
@@ -1,7 +1,6 @@
-/* Copyright (C) 1997, 1998, 2002, 2003-2005, 2017
-   Free Software Foundation, Inc.
+/* Miscellaneous macros.
+   Copyright (C) 2000-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Ralf Baechle <ralf@gnu.org>.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _SYS_ASM_H
 #define _SYS_ASM_H

--- a/sysdeps/riscv/tst-audit.h
+++ b/sysdeps/riscv/tst-audit.h
@@ -1,7 +1,5 @@
 /* Definitions for testing PLT entry/exit auditing.  RISC-V version.
-
-   Copyright (C) 2005, 2017 Free Software Foundation, Inc.
-
+   Copyright (C) 2005-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -15,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #define pltenter la_riscv_gnu_pltenter
 #define pltexit la_riscv_gnu_pltexit

--- a/sysdeps/unix/sysv/linux/riscv/atomic-machine.h
+++ b/sysdeps/unix/sysv/linux/riscv/atomic-machine.h
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _LINUX_RISCV_BITS_ATOMIC_H
 #define _LINUX_RISCV_BITS_ATOMIC_H 1

--- a/sysdeps/unix/sysv/linux/riscv/bits/mman.h
+++ b/sysdeps/unix/sysv/linux/riscv/bits/mman.h
@@ -1,6 +1,5 @@
 /* Definitions for POSIX memory map interface.  Linux/RISC-V version.
-   Copyright (C) 1997, 2000, 2003, 2004, 2005, 2006, 2009, 2011, 2017
-   Free Software Foundation, Inc.
+   Copyright (C) 1997-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _SYS_MMAN_H
 # error "Never use <bits/mman.h> directly; include <sys/mman.h> instead."

--- a/sysdeps/unix/sysv/linux/riscv/bits/sigcontext.h
+++ b/sysdeps/unix/sysv/linux/riscv/bits/sigcontext.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 1996, 1997, 1998, 2003, 2004, 2006, 2017 Free Software
+/* Machine-dependent signal context structure for Linux.  RISC-V version.
+   Copyright (C) 1996-2017 Free Software
    Foundation, Inc.  This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _BITS_SIGCONTEXT_H
 #define _BITS_SIGCONTEXT_H 1

--- a/sysdeps/unix/sysv/linux/riscv/clone.S
+++ b/sysdeps/unix/sysv/linux/riscv/clone.S
@@ -1,6 +1,6 @@
-/* Copyright (C) 1996-2017 Free Software Foundation, Inc.
+/* Wrapper around clone system call.  RISC-V version.
+   Copyright (C) 1996-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Ralf Baechle <ralf@linux-mips.org>, 1996.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 /* clone() is even more special than fork() as it mucks with stacks
    and invokes a function in the right context after its all over.  */

--- a/sysdeps/unix/sysv/linux/riscv/dl-static.c
+++ b/sysdeps/unix/sysv/linux/riscv/dl-static.c
@@ -1,5 +1,5 @@
 /* Variable initialization.  RISC-V version
-   Copyright (C) 2001-2003, 2005, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2001-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <ldsodefs.h>
 

--- a/sysdeps/unix/sysv/linux/riscv/getcontext.S
+++ b/sysdeps/unix/sysv/linux/riscv/getcontext.S
@@ -1,7 +1,6 @@
 /* Save current context.
-   Copyright (C) 2009, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2009-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Maciej W. Rozycki <macro@codesourcery.com>.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, 51 Franklin Street - Fifth Floor, Boston, MA
-   02110-1301, USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sysdep.h>
 #include <sys/asm.h>

--- a/sysdeps/unix/sysv/linux/riscv/kernel-features.h
+++ b/sysdeps/unix/sysv/linux/riscv/kernel-features.h
@@ -1,4 +1,6 @@
-/* Copyright (C) 2014, 2017 Free Software Foundation, Inc.
+/* Set flags signalling availability of kernel features based on given
+   kernel version number.  RISC-V version.
+   Copyright (C) 2014-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/unix/sysv/linux/riscv/ldconfig.h
+++ b/sysdeps/unix/sysv/linux/riscv/ldconfig.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2001, 2002, 2003, 2017 Free Software Foundation, Inc.
+/* ldconfig default paths and libraries.  Linux/RISC-V version.
+   Copyright (C) 2001-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sysdeps/generic/ldconfig.h>
 

--- a/sysdeps/unix/sysv/linux/riscv/ldsodefs.h
+++ b/sysdeps/unix/sysv/linux/riscv/ldsodefs.h
@@ -1,6 +1,6 @@
 /* Run-time dynamic linker data structures for loaded ELF shared objects.
-   RISC-V
-   Copyright (C) 2001, 2003, 2017 Free Software Foundation, Inc.
+   RISC-V version.
+   Copyright (C) 2001-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -14,9 +14,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef	_LDSODEFS_H
 

--- a/sysdeps/unix/sysv/linux/riscv/makecontext.c
+++ b/sysdeps/unix/sysv/linux/riscv/makecontext.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2001-2003, 2005, 2017 Free Software Foundation, Inc.
+/* Create new context.  RISC-V version.
+   Copyright (C) 2001-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,10 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
-
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sysdep.h>
 #include <sys/asm.h>

--- a/sysdeps/unix/sysv/linux/riscv/register-dump.h
+++ b/sysdeps/unix/sysv/linux/riscv/register-dump.h
@@ -1,7 +1,6 @@
 /* Dump registers.
-   Copyright (C) 2000, 2001, 2002, 2006, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2000-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@suse.de>, 2000.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <unistd.h>
 #include <string.h>

--- a/sysdeps/unix/sysv/linux/riscv/setcontext.S
+++ b/sysdeps/unix/sysv/linux/riscv/setcontext.S
@@ -1,7 +1,6 @@
 /* Set current context.
-   Copyright (C) 2009, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2009-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Maciej W. Rozycki <macro@codesourcery.com>.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, 51 Franklin Street - Fifth Floor, Boston, MA
-   02110-1301, USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sysdep.h>
 #include <sys/asm.h>

--- a/sysdeps/unix/sysv/linux/riscv/sigcontextinfo.h
+++ b/sysdeps/unix/sysv/linux/riscv/sigcontextinfo.h
@@ -1,6 +1,6 @@
-/* Copyright (C) 2000, 2001, 2003, 2004, 2017 Free Software Foundation, Inc.
+/* RISC-V definitions for signal handling calling conventions.
+   Copyright (C) 2000-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Andreas Jaeger <aj@suse.de>, 2000.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sys/ucontext.h>
 

--- a/sysdeps/unix/sysv/linux/riscv/swapcontext.S
+++ b/sysdeps/unix/sysv/linux/riscv/swapcontext.S
@@ -1,7 +1,6 @@
 /* Save and set current context.
-   Copyright (C) 2009, 2017 Free Software Foundation, Inc.
+   Copyright (C) 2009-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
-   Contributed by Maciej W. Rozycki <macro@codesourcery.com>.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -14,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, 51 Franklin Street - Fifth Floor, Boston, MA
-   02110-1301, USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sysdep.h>
 #include <sys/asm.h>

--- a/sysdeps/unix/sysv/linux/riscv/sys/procfs.h
+++ b/sysdeps/unix/sysv/linux/riscv/sys/procfs.h
@@ -1,5 +1,5 @@
-/* Copyright (C) 1996, 1997, 1999, 2000, 2002, 2003, 2004, 2017
-	Free Software Foundation, Inc.
+/* Core image file related definitions, RISC-V version.
+   Copyright (C) 1996-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -13,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #ifndef _SYS_PROCFS_H
 #define _SYS_PROCFS_H	1

--- a/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
+++ b/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
@@ -1,5 +1,6 @@
-/* Copyright (C) 1997, 1998, 2000, 2003, 2004, 2006, 2009, 2017 Free Software
-   Foundation, Inc.  This file is part of the GNU C Library.
+/* struct ucontext definition, RISC-V version.
+   Copyright (C) 1997-2017 Free Software Foundation, Inc.  
+   This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 /* Don't rely on this, the interface is currently messed up and may need to
    be broken to be fixed.  */

--- a/sysdeps/unix/sysv/linux/riscv/syscall.c
+++ b/sysdeps/unix/sysv/linux/riscv/syscall.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2001-2003, 2005, 2017 Free Software Foundation, Inc.
+/* system call interface.  Linux/RISC-V version.
+   Copyright (C) 2001-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sysdep.h>
 

--- a/sysdeps/unix/sysv/linux/riscv/sysdep-cancel.h
+++ b/sysdeps/unix/sysv/linux/riscv/sysdep-cancel.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2003-2006, 2017 Free Software Foundation, Inc.
+/* Assembler macros with cancellation support, RISC-V version.
+   Copyright (C) 2003-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 #include <sysdep.h>
 #include <sysdeps/generic/sysdep.h>

--- a/sysdeps/unix/sysv/linux/riscv/sysdep.S
+++ b/sysdeps/unix/sysv/linux/riscv/sysdep.S
@@ -1,5 +1,5 @@
-/* Copyright (C) 2011-2017 Free Software Foundation, Inc.
-   Contributed by Andrew Waterman (andrew@sifive.com).
+/* syscall error handlers
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/unix/sysv/linux/riscv/sysdep.h
+++ b/sysdeps/unix/sysv/linux/riscv/sysdep.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2011-2014, 2017
+/* Assembly macros for RISC-V.
+   Copyright (C) 2011-2017
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or

--- a/sysdeps/unix/sysv/linux/riscv/vfork.S
+++ b/sysdeps/unix/sysv/linux/riscv/vfork.S
@@ -1,4 +1,5 @@
-/* Copyright (C) 2005, 2017 Free Software Foundation, Inc.
+/* vfork for Linux, RISC-V version.
+   Copyright (C) 2005-2017 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -12,9 +13,8 @@
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
-   License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   License along with the GNU C Library.  If not, see
+   <http://www.gnu.org/licenses/>.  */
 
 /* vfork() is just a special case of clone().  */
 


### PR DESCRIPTION
Specifically:
  - Remove "contributed by" lines,
  - Single range of years for copyright,
  - URL instead of postal address, and
  - Descriptive comment on first line (or two) of the file.