### PR TITLE
sysdeps/riscv: Execute preconfiure only for risv target

### DIFF
--- a/sysdeps/riscv/preconfigure
+++ b/sysdeps/riscv/preconfigure
@@ -1,50 +1,53 @@
-xlen=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_xlen \(.*\)/\1/p'`
-flen=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_flen \(.*\)/\1/p'`
-float_abi=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_float_abi_\([^ ]*\) .*/\1/p'`
+case "$machine" in
+riscv*)
+  xlen=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_xlen \(.*\)/\1/p'`
+  flen=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_flen \(.*\)/\1/p'`
+  float_abi=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | sed -n 's/^#define __riscv_float_abi_\([^ ]*\) .*/\1/p'`
 
-case "$xlen" in
-32 | 64)
-	;;
-*)
-	echo "Unable to determine XLEN" >&2
-	exit 1
-	;;
+  case "$xlen" in
+  32 | 64)
+    ;;
+  *)
+    echo "Unable to determine XLEN" >&2
+    exit 1
+    ;;
+  esac
+
+  case "$flen" in
+  64)
+    float_machine=rvd
+    ;;
+  32)
+    float_machine=rvf
+    ;;
+  "")
+    float_machine=
+    ;;
+   *)
+    echo "Unable to determine FLEN" >&2
+    exit 1
+    ;;
+  esac
+
+  case "$float_abi" in
+  soft)
+    abi_flen=0
+    ;;
+  single)
+    abi_flen=32
+    ;;
+  double)
+    abi_flen=64
+    ;;
+  *)
+    echo "Unable to determine floating-point ABI" >&2
+    exit 1
+    ;;
+  esac
+
+  base_machine=riscv
+  machine=riscv/rv$xlen/$float_machine
+
+  $as_echo "#define RISCV_ABI_XLEN $xlen" >>confdefs.h
+  $as_echo "#define RISCV_ABI_FLEN $abi_flen" >>confdefs.h
 esac
-
-case "$flen" in
-64)
-	float_machine=rvd
-	;;
-32)
-	float_machine=rvf
-	;;
-"")
-	float_machine=
-	;;
-*)
-	echo "Unable to determine FLEN" >&2
-	exit 1
-	;;
-esac
-
-case "$float_abi" in
-soft)
-	abi_flen=0
-	;;
-single)
-	abi_flen=32
-	;;
-double)
-	abi_flen=64
-	;;
-*)
-	echo "Unable to determine floating-point ABI" >&2
-	exit 1
-	;;
-esac
-
-base_machine=riscv
-machine=riscv/rv$xlen/$float_machine
-
-$as_echo "#define RISCV_ABI_XLEN $xlen" >>confdefs.h
-$as_echo "#define RISCV_ABI_FLEN $abi_flen" >>confdefs.h


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>