### PR TITLE
Fix mcontext_t sigcontext namespace for riscv

### DIFF
--- a/sysdeps/unix/sysv/linux/riscv/register-dump.h
+++ b/sysdeps/unix/sysv/linux/riscv/register-dump.h
@@ -32,7 +32,7 @@ hexvalue (unsigned long int value, char *buf, size_t len)
 #define REGDUMP_PER_LINE (80 / (__WORDSIZE/4 + 4))
 
 static void
-register_dump (int fd, struct ucontext *ctx)
+register_dump (int fd, ucontext_t *ctx)
 {
   int i;
   char regvalue[__WORDSIZE/4 + 1];

--- a/sysdeps/unix/sysv/linux/riscv/sigcontextinfo.h
+++ b/sysdeps/unix/sysv/linux/riscv/sigcontextinfo.h
@@ -18,7 +18,7 @@
 
 #include <sys/ucontext.h>
 
-#define SIGCONTEXT siginfo_t *_si, struct ucontext *
+#define SIGCONTEXT siginfo_t *_si, ucontext_t *
 #define SIGCONTEXT_EXTRA_ARGS _si,
 #define GET_PC(ctx)	((void *) ctx->uc_mcontext.gregs[REG_PC])
 #define GET_FRAME(ctx)	((void *) ctx->uc_mcontext.gregs[REG_S0])

--- a/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
+++ b/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
@@ -24,8 +24,13 @@
 #include <features.h>
 
 #include <bits/types/sigset_t.h>
-#include <bits/sigcontext.h>
 #include <bits/types/stack_t.h>
+
+#ifdef __USE_MISC
+# define __ctx(fld) fld
+#else
+# define __ctx(fld) __ ## fld
+#endif
 
 #ifdef __USE_MISC
 
@@ -47,16 +52,19 @@ typedef greg_t gregset_t[NGREG];
 /* Container for floating-point state.  */
 typedef union __riscv_fp_state fpregset_t;
 
-/* Context to describe whole processor state.  */
-typedef struct sigcontext mcontext_t;
-
 #endif
+typedef struct mcontext_t
+  {
+    /* gregs[0] holds the program counter. */
+    unsigned long __ctx(gregs)[32];
+    unsigned long long __ctx(fpregs)[66] __attribute__((aligned(16)));
+  } mcontext_t;
 
 /* Userlevel context.  */
-typedef struct ucontext
+typedef struct ucontext_t
   {
     unsigned long int uc_flags;
-    struct ucontext *uc_link;
+    struct ucontext_t *uc_link;
     stack_t uc_stack;
     sigset_t uc_sigmask;
     mcontext_t uc_mcontext;


### PR DESCRIPTION
implement bug 21457 for riscv as well

Inclusion of <bits/sigcontext.h> by <sys/ucontext.h> is removedi

on riscv Where mcontext_t was typedefed to struct sigcontext, the contents of
struct sigcontext are inserted (with appropriate namespace handling to
prefix fields with __ when __USE_MISC is not defined)
definition of struct sigcontext comes from glibc headers

Signed-off-by: Khem Raj <raj.khem@gmail.com>