### PR TITLE
Fix backtrace support (and test failures).

### DIFF
--- a/sysdeps/riscv/backtrace.c
+++ b/sysdeps/riscv/backtrace.c
@@ -1,0 +1,1 @@
+#include <sysdeps/x86_64/backtrace.c>


### PR DESCRIPTION
Apparently the generic support is broken and x86_64 is the de
facto generic, so use that.