### PR TITLE
RISC-V: Fix makecontext testsuite failures.

### DIFF
--- a/sysdeps/unix/sysv/linux/riscv/makecontext.c
+++ b/sysdeps/unix/sysv/linux/riscv/makecontext.c
@@ -39,9 +39,9 @@ __makecontext (ucontext_t *ucp, void (*func) (void), int argc,
      s1 = the function we must call.
      s2 = the subsequent context to run.  */
   ucp->uc_mcontext.gregs[REG_RA] = 0;
-  ucp->uc_mcontext.gregs[REG_S0 + 0] = 0;
-  ucp->uc_mcontext.gregs[REG_S0 + 1] = (long)func;
-  ucp->uc_mcontext.gregs[REG_S0 + 2] = (long)ucp->uc_link;
+  ucp->uc_mcontext.gregs[REG_S0] = 0;
+  ucp->uc_mcontext.gregs[REG_S1] = (long)func;
+  ucp->uc_mcontext.gregs[REG_S2] = (long)ucp->uc_link;
   ucp->uc_mcontext.gregs[REG_SP] = sp;
   ucp->uc_mcontext.gregs[REG_PC] = (long)&__start_context;
 

--- a/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
+++ b/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
@@ -36,7 +36,9 @@
 #define REG_SP 2
 #define REG_TP 4
 #define REG_S0 8
+#define REG_S1 9
 #define REG_A0 10
+#define REG_S2 18
 #define REG_NARGS 8
 
 typedef unsigned long greg_t;


### PR DESCRIPTION
	* sysdeps/unix/sysv/linux/riscv/sys/ucontext.h (REG_S1, REG_S2): New.
	* sysdeps/unix/sysv/linux/riscv/makecontext.c (__makecontext): Use
	new defines.