### PR TITLE
RISC-V: Fix pie1 testsuite failure.

### DIFF
--- a/sysdeps/riscv/start.S
+++ b/sysdeps/riscv/start.S
@@ -45,7 +45,8 @@
 ENTRY(ENTRY_POINT)
 	call  .Lload_gp
 	mv    a5, a0  /* rtld_fini */
-	lla   a0, main
+	/* main may be in a shared library.  */
+	la   a0, main
 	REG_L a1, 0(sp)      /* argc */
 	addi  a2, sp, SZREG  /* argv */
 	andi  sp, sp, ALMASK /* Align stack. */


### PR DESCRIPTION
	* sysdeps/riscv/start.S (ENTRY_POINT): Use la instead of lla for main.