### PR TITLE
Fix testsuite failures

### DIFF
--- a/sysdeps/riscv/start.S
+++ b/sysdeps/riscv/start.S
@@ -45,7 +45,8 @@
 ENTRY (ENTRY_POINT)
 	call  .Lload_gp
 	mv    a5, a0  /* rtld_fini */
-	lla   a0, main
+	/* main may be in a shared library.  */
+	la   a0, main
 	REG_L a1, 0(sp)      /* argc */
 	addi  a2, sp, SZREG  /* argv */
 	andi  sp, sp, ALMASK /* Align stack. */

--- a/sysdeps/riscv/tls-macros.h
+++ b/sysdeps/riscv/tls-macros.h
@@ -45,16 +45,17 @@
 	({ void *__result;				\
 	asm (LOAD_GP					\
 	     "la.tls.ie %0, " #x "\n\t"			\
+	     "add %0, %0, tp\n\t"			\
 	     UNLOAD_GP					\
 	     : "=r" (__result));			\
-	__tls_get_addr (__result); })
+	__result; })
 
 #define TLS_LE(x)					\
 	({ void *__result;				\
 	asm (LOAD_GP					\
 	     "lui %0, %%tprel_hi(" #x ")\n\t"		\
 	     "add %0, %0, tp, %%tprel_add(" #x ")\n\t"	\
-	     "lw %0, %%tprel_lo(" #x ")(%0)\n\t"	\
+	     "addi %0, %0, %%tprel_lo(" #x ")\n\t"	\
 	     UNLOAD_GP					\
 	     : "=r" (__result));			\
-	__tls_get_addr (__result); })
+	__result; })

--- a/sysdeps/unix/sysv/linux/riscv/clone.S
+++ b/sysdeps/unix/sysv/linux/riscv/clone.S
@@ -76,8 +76,9 @@ L (thread_start):
 	/* Call the user's function.  */
 	jalr		a1
 
-	/* Call _exit with the function's return value.  */
-	j		_exit
+	/* Call exit with the function's return value.  */
+	li		a7, __NR_exit
+	scall
 
 	END (__thread_start)
 

--- a/sysdeps/unix/sysv/linux/riscv/makecontext.c
+++ b/sysdeps/unix/sysv/linux/riscv/makecontext.c
@@ -40,9 +40,9 @@ __makecontext (ucontext_t *ucp, void (*func) (void), int argc,
      s1 = the function we must call.
      s2 = the subsequent context to run.  */
   ucp->uc_mcontext.__gregs[REG_RA] = 0;
-  ucp->uc_mcontext.__gregs[REG_S0 + 0] = 0;
-  ucp->uc_mcontext.__gregs[REG_S0 + 1] = (long int) func;
-  ucp->uc_mcontext.__gregs[REG_S0 + 2] = (long int) ucp->uc_link;
+  ucp->uc_mcontext.__gregs[REG_S0] = 0;
+  ucp->uc_mcontext.__gregs[REG_S1] = (long int) func;
+  ucp->uc_mcontext.__gregs[REG_S2] = (long int) ucp->uc_link;
   ucp->uc_mcontext.__gregs[REG_SP] = sp;
   ucp->uc_mcontext.__gregs[REG_PC] = (long int) &__start_context;
 

--- a/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
+++ b/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
@@ -36,7 +36,9 @@ typedef unsigned long int __riscv_mc_gp_state[32];
 # define REG_SP 2
 # define REG_TP 4
 # define REG_S0 8
+# define REG_S1 9
 # define REG_A0 10
+# define REG_S2 18
 # define REG_NARGS 8
 
 typedef unsigned long int greg_t;


### PR DESCRIPTION
Includes changes from the following branches, cherry picked and manually merged to riscv-for-submission-v4:
  - jim-wilson/makecontext-s2
  - jim-wilson/start-pie
  - jim-wilson/tls-macros