### PR TITLE
RISC-V: Fixes makecontext3 testsuite failure.

### DIFF
--- a/sysdeps/unix/sysv/linux/riscv/makecontext.c
+++ b/sysdeps/unix/sysv/linux/riscv/makecontext.c
@@ -58,11 +58,17 @@ __makecontext (ucontext_t *ucp, void (*func) (void), int argc,
       va_start (vl, a4);
 
       long reg_args = argc < REG_NARGS ? argc : REG_NARGS;
-      sp = (sp - (argc - reg_args) * sizeof (long)) & ALMASK;
       for (i = 5; i < reg_args; i++)
         ucp->uc_mcontext.gregs[REG_A0 + i] = va_arg (vl, long);
-      for (i = 0; i < argc - reg_args; i++)
-        ((long*)sp)[i] = va_arg (vl, long);
+
+      long int stack_args = argc - reg_args;
+      if (stack_args > 0)
+	{
+	  sp = (sp - stack_args * sizeof (long int)) & ALMASK;
+	  ucp->uc_mcontext.gregs[REG_SP] = sp;
+	  for (i = 0; i < stack_args; i++)
+	    ((long int *) sp)[i] = va_arg (vl, long int);
+	}
 
       va_end (vl);
     }


### PR DESCRIPTION
Conditionally update SP register value in context if store args on the stack.