### PR TITLE
Using tail rather than j when calling __syscall_error

### DIFF
--- a/sysdeps/riscv/setjmp.S
+++ b/sysdeps/riscv/setjmp.S
@@ -64,7 +64,7 @@ ENTRY (__sigsetjmp)
   ret
 #else
   /* Make a tail call to __sigjmp_save; it takes the same args.  */
-  j __sigjmp_save
+  tail __sigjmp_save
 #endif
 
 

--- a/sysdeps/unix/sysv/linux/riscv/clone.S
+++ b/sysdeps/unix/sysv/linux/riscv/clone.S
@@ -60,7 +60,7 @@ L(invalid):
 	li		a0, -EINVAL
 	/* Something bad happened -- no child created */
 L(error):
-	j		__syscall_error
+	tail		__syscall_error
 	END(__clone)
 
 /* Load up the arguments to the function.  Put this block of code in
@@ -77,7 +77,7 @@ L(thread_start):
 	jalr		a1
 
 	/* Call _exit with the function's return value.  */
-	j		_exit
+	tail		_exit
 
 	END(__thread_start)
 

--- a/sysdeps/unix/sysv/linux/riscv/getcontext.S
+++ b/sysdeps/unix/sysv/linux/riscv/getcontext.S
@@ -70,7 +70,7 @@ LEAF (__getcontext)
 
 	ret
 
-99:	j	__syscall_error
+99:	tail	__syscall_error
 
 PSEUDO_END (__getcontext)
 

--- a/sysdeps/unix/sysv/linux/riscv/setcontext.S
+++ b/sysdeps/unix/sysv/linux/riscv/setcontext.S
@@ -92,7 +92,7 @@ LEAF (__setcontext)
 
 	jr	t1
 
-99:	j	__syscall_error
+99:	tail	__syscall_error
 
 PSEUDO_END (__setcontext)
 weak_alias (__setcontext, setcontext)
@@ -108,7 +108,7 @@ LEAF (__start_context)
 	/* Invoke subsequent context if present, else exit(0).  */
 	mv	a0, s2
 	beqz	s2, 1f
-	jal	__setcontext
-1:	j	exit
+	call	__setcontext
+1:	tail	exit
 
 PSEUDO_END (__start_context)

--- a/sysdeps/unix/sysv/linux/riscv/swapcontext.S
+++ b/sysdeps/unix/sysv/linux/riscv/swapcontext.S
@@ -118,7 +118,7 @@ LEAF (__swapcontext)
 	jr	t1
 
 
-99:	j	__syscall_error
+99:	tail	__syscall_error
 
 PSEUDO_END (__swapcontext)
 

--- a/sysdeps/unix/sysv/linux/riscv/sysdep-cancel.h
+++ b/sysdeps/unix/sysv/linux/riscv/sysdep-cancel.h
@@ -34,7 +34,7 @@
 # define PSEUDO(name, syscall_name, args)				\
       .align 2;								\
   L(pseudo_start):							\
-  99: j __syscall_error;						\
+  99: tail __syscall_error;						\
   ENTRY (name)								\
     SINGLE_THREAD_P(t0);						\
     bnez t0, L(pseudo_cancel);  					\

--- a/sysdeps/unix/sysv/linux/riscv/sysdep.h
+++ b/sysdeps/unix/sysv/linux/riscv/sysdep.h
@@ -73,7 +73,7 @@
 # else
 #  define SYSCALL_ERROR_HANDLER(name)				\
 .Lsyscall_error ## name:					\
-        j       __syscall_error;
+        tail       __syscall_error;
 # endif
 
 /* Performs a system call, not setting errno.  */

--- a/sysdeps/unix/sysv/linux/riscv/vfork.S
+++ b/sysdeps/unix/sysv/linux/riscv/vfork.S
@@ -36,7 +36,7 @@ LEAF(__libc_vfork)
 	bltz	a0, 1f
 	ret
 
-1:	j		__syscall_error
+1:	tail		__syscall_error
 END(__libc_vfork)
 
 weak_alias (__libc_vfork, vfork)


### PR DESCRIPTION
It fix some issue in mailing list sw-dev[1], @palmer-dabbelt how do you think about that? Should we replace *all* function call/jump to call/tail instead of j/jal in glibc? I only fix function calls for __syscall_error, but other function calls has same issue in some assembly file too.

[1] https://groups.google.com/a/groups.riscv.org/forum/?#!msg/sw-dev/sPgOZYP6uAA/iFYS1eNOCgAJ