### PR TITLE
RISC-V: Fix compilation error in ucontext.h with _XOPEN_SOURCE

### DIFF
--- a/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
+++ b/sysdeps/unix/sysv/linux/riscv/sys/ucontext.h
@@ -49,10 +49,10 @@ typedef greg_t gregset_t[NGREG];
 /* Container for floating-point state.  */
 typedef union __riscv_fp_state fpregset_t;
 
+#endif
+
 /* Context to describe whole processor state.  */
 typedef struct sigcontext mcontext_t;
-
-#endif
 
 /* Userlevel context.  */
 typedef struct ucontext


### PR DESCRIPTION
The typedef was on the wrong side of the #endif.  Minimal source code to reproduce the problem:
```
#define _XOPEN_SOURCE 700
#include <sys/wait.h>
```

I encountered this issue when running `emerge -e @world` in Gentoo on the HiFive Unleashed, and it tried to rebuild busybox.